### PR TITLE
Feature/hbs partial helpers add parameter support

### DIFF
--- a/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
+++ b/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
@@ -115,7 +115,7 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
         [TestCase(12)]
         [TestCase(12.0)]
         [TestCase('f')]
-        public void given_path_and_context_where_context_is_generic_type(object input)
+        public void given_path_and_context_where_context_is_base_type(object input)
         {
             var source = "{{{dynPartial 'partialName' foo}}}";
             var partialSource = "test {{this}}";

--- a/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
+++ b/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
@@ -6,7 +6,7 @@ using YuzuDelivery.Core;
 namespace YuzuDelivery.Core.Test.HbsHelpers
 {
     
-    public class DynPartial
+    public class DynPartialTests
     {
         private YuzuDelivery.Core.DynPartial helper;
         [SetUp]
@@ -39,8 +39,131 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var output = template(data);
             Assert.AreEqual("test foo bar", output);
         }
-
         
+        [Test]
+        [TestCase("foo bar")]
+        [TestCase(12)]
+        [TestCase(12.0)]
+        [TestCase('f')]
+        public void given_path_and_context_where_context_is_a_base_type(object input)
+        {
+            var source = "{{{dynPartial 'partialName' foo}}}";
+            var partialSource = "test {{this}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = input
+            };
+
+            var output = template(data);
+            Assert.AreEqual($"test {input}", output);
+        }
+
+        [Test]
+        public void given_path_context_and_parameter()
+        {
+            var source = "{{{dynPartial 'partialName' foo param='test'}}}";
+            var partialSource = "test {{bar}} {{param}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar test", output);
+        }
+
+        [Test]
+        public void given_path_context_and_multiple_parameters()
+        {
+            var source = "{{{dynPartial 'partialName' foo param1='test' param2='test again'}}}";
+            var partialSource = "test {{bar}} {{param1}} {{param2}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar test test again", output);
+        }
   
+        [Test]
+        public void given_path_no_context()
+        {
+            var source = "{{{dynPartial 'partialName'}}}";
+            var partialSource = "test {{foo.bar}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar", output);
+        }
+        [Test]
+        public void given_path_no_context_with_parameter()
+        {
+            var source = "{{{dynPartial 'partialName' param='test'}}}";
+            var partialSource = "test {{foo.bar}} {{param}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar test", output);
+        }
+        
     }
 }

--- a/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
+++ b/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using HandlebarsDotNet;
+using NUnit.Framework;
+using YuzuDelivery.Core;
+
+namespace YuzuDelivery.Core.Test.HbsHelpers
+{
+    
+    public class DynPartial
+    {
+        private YuzuDelivery.Core.DynPartial helper;
+        [SetUp]
+        public void Setup()
+        {
+            helper = new YuzuDelivery.Core.DynPartial();
+        }
+        
+        [Test]
+        public void given_path_and_context_where_context_is_an_object()
+        {
+            var source = "{{{dynPartial 'partialName' foo}}}";
+            var partialSource = "test {{bar}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar", output);
+        }
+
+        
+  
+    }
+}

--- a/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
+++ b/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
@@ -1,33 +1,103 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using HandlebarsDotNet;
 using NUnit.Framework;
 using YuzuDelivery.Core;
 
 namespace YuzuDelivery.Core.Test.HbsHelpers
 {
-    
+    public class vmBlock_PartialName
+    {
+       
+        public vmBlock_PartialName()
+        {
+            Bar = "bar";
+        }
+
+        public string Bar { get; set; }
+    }
+
     public class DynPartialTests
     {
         private YuzuDelivery.Core.DynPartial helper;
+
         [SetUp]
         public void Setup()
         {
             helper = new YuzuDelivery.Core.DynPartial();
         }
-        
+
+        [Test]
+        public void given_empty_path_and_context()
+        {
+            var source = "{{{dynPartial '' foo}}}";
+            var partialSource = "test {{bar}}";
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("parPartialName", partialTemplate);
+            }
+
+            var data = new { foo = new vmBlock_PartialName() };
+
+            var output = template(data);
+            Assert.AreEqual("test bar", output);
+        }
+
+        [Test]
+        public void given_empty_path_context_and_parameter()
+        {
+            var source = "{{{dynPartial '' foo param='test'}}}";
+            var partialSource = "test {{bar}} {{param}}";
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("parPartialName", partialTemplate);
+            }
+
+            var data = new { foo = new vmBlock_PartialName() };
+
+            var output = template(data);
+            Assert.AreEqual("test bar test", output);
+        }
+
+        [Test]
+        public void given_empty_path_and_context_is_array()
+        {
+            var source = "{{{dynPartial '' foo}}}";
+            var partialSource = "test {{#each this}}{{this.bar}}{{/each}}";
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("parPartialName", partialTemplate);
+            }
+
+            var data = new { foo = new[] { new vmBlock_PartialName() } };
+
+            var output = template(data);
+            Assert.AreEqual("test bar", output);
+        }
+
+
         [Test]
         public void given_path_and_context_where_context_is_an_object()
         {
             var source = "{{{dynPartial 'partialName' foo}}}";
             var partialSource = "test {{bar}}";
             var template = Handlebars.Compile(source);
-            
-            using(var reader = new StringReader(partialSource))
+
+            using (var reader = new StringReader(partialSource))
             {
                 var partialTemplate = Handlebars.Compile(reader);
                 Handlebars.RegisterTemplate("partialName", partialTemplate);
             }
-            
+
             var data = new
             {
                 foo = new
@@ -39,24 +109,24 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var output = template(data);
             Assert.AreEqual("test foo bar", output);
         }
-        
+
         [Test]
         [TestCase("foo bar")]
         [TestCase(12)]
         [TestCase(12.0)]
         [TestCase('f')]
-        public void given_path_and_context_where_context_is_a_base_type(object input)
+        public void given_path_and_context_where_context_is_generic_type(object input)
         {
             var source = "{{{dynPartial 'partialName' foo}}}";
             var partialSource = "test {{this}}";
             var template = Handlebars.Compile(source);
-            
-            using(var reader = new StringReader(partialSource))
+
+            using (var reader = new StringReader(partialSource))
             {
                 var partialTemplate = Handlebars.Compile(reader);
                 Handlebars.RegisterTemplate("partialName", partialTemplate);
             }
-            
+
             var data = new
             {
                 foo = input
@@ -72,13 +142,13 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var source = "{{{dynPartial 'partialName' foo param='test'}}}";
             var partialSource = "test {{bar}} {{param}}";
             var template = Handlebars.Compile(source);
-            
-            using(var reader = new StringReader(partialSource))
+
+            using (var reader = new StringReader(partialSource))
             {
                 var partialTemplate = Handlebars.Compile(reader);
                 Handlebars.RegisterTemplate("partialName", partialTemplate);
             }
-            
+
             var data = new
             {
                 foo = new
@@ -97,13 +167,13 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var source = "{{{dynPartial 'partialName' foo param1='test' param2='test again'}}}";
             var partialSource = "test {{bar}} {{param1}} {{param2}}";
             var template = Handlebars.Compile(source);
-            
-            using(var reader = new StringReader(partialSource))
+
+            using (var reader = new StringReader(partialSource))
             {
                 var partialTemplate = Handlebars.Compile(reader);
                 Handlebars.RegisterTemplate("partialName", partialTemplate);
             }
-            
+
             var data = new
             {
                 foo = new
@@ -115,20 +185,20 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var output = template(data);
             Assert.AreEqual("test foo bar test test again", output);
         }
-  
+
         [Test]
         public void given_path_no_context()
         {
             var source = "{{{dynPartial 'partialName'}}}";
             var partialSource = "test {{foo.bar}}";
             var template = Handlebars.Compile(source);
-            
-            using(var reader = new StringReader(partialSource))
+
+            using (var reader = new StringReader(partialSource))
             {
                 var partialTemplate = Handlebars.Compile(reader);
                 Handlebars.RegisterTemplate("partialName", partialTemplate);
             }
-            
+
             var data = new
             {
                 foo = new
@@ -140,19 +210,20 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var output = template(data);
             Assert.AreEqual("test foo bar", output);
         }
+
         [Test]
         public void given_path_no_context_with_parameter()
         {
             var source = "{{{dynPartial 'partialName' param='test'}}}";
             var partialSource = "test {{foo.bar}} {{param}}";
             var template = Handlebars.Compile(source);
-            
-            using(var reader = new StringReader(partialSource))
+
+            using (var reader = new StringReader(partialSource))
             {
                 var partialTemplate = Handlebars.Compile(reader);
                 Handlebars.RegisterTemplate("partialName", partialTemplate);
             }
-            
+
             var data = new
             {
                 foo = new
@@ -164,6 +235,5 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var output = template(data);
             Assert.AreEqual("test foo bar test", output);
         }
-        
     }
 }

--- a/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
+++ b/YuzuDelivery.Core.Test/HbsHelpers/DynPartialTests.cs
@@ -135,6 +135,26 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             var output = template(data);
             Assert.AreEqual($"test {input}", output);
         }
+        
+        [Test]
+        public void given_empty_path_context_where_context_is_generic_type()
+        {
+            var source = "{{{dynPartial 'parPartialName' foo}}}";
+            var partialSource = "test {{this.[0].bar}}";
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("parPartialName", partialTemplate);
+            }
+
+            var data = new { foo = new List<vmBlock_PartialName>() {new vmBlock_PartialName() } };
+
+            var output = template(data);
+            Assert.AreEqual("test bar", output);
+        }
+
 
         [Test]
         public void given_path_context_and_parameter()

--- a/YuzuDelivery.Core.Test/HbsHelpers/ModPartialTests.cs
+++ b/YuzuDelivery.Core.Test/HbsHelpers/ModPartialTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using HandlebarsDotNet;
 using NUnit.Framework;
 using YuzuDelivery.Core;
@@ -15,6 +16,63 @@ namespace YuzuDelivery.Core.Test.HbsHelpers
             helper = new YuzuDelivery.Core.ModPartial();
         }
         
+                [Test]
+        public void given_empty_path_and_context()
+        {
+            var source = "{{{modPartial '' foo ''}}}";
+            var partialSource = "test {{bar}}";
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("parPartialName", partialTemplate);
+            }
+
+            var data = new { foo = new vmBlock_PartialName() };
+
+            var output = template(data);
+            Assert.AreEqual("test bar", output);
+        }
+
+        [Test]
+        public void given_empty_path_context_and_parameter()
+        {
+            var source = "{{{modPartial '' foo '' param='test'}}}";
+            var partialSource = "test {{bar}} {{param}}";
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("parPartialName", partialTemplate);
+            }
+
+            var data = new { foo = new vmBlock_PartialName() };
+
+            var output = template(data);
+            Assert.AreEqual("test bar test", output);
+        }
+
+        [Test]
+        public void given_empty_path_and_context_is_array()
+        {
+            var source = "{{{modPartial '' foo ''}}}";
+            var partialSource = "test {{#each this}}{{this.bar}}{{/each}}";
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("parPartialName", partialTemplate);
+            }
+
+            var data = new { foo = new[] { new vmBlock_PartialName() } };
+
+            var output = template(data);
+            Assert.AreEqual("test bar", output);
+        }
+
         [Test]
         public void given_path_and_context_where_context_is_an_object_and_modifiers_is_empty()
         {

--- a/YuzuDelivery.Core.Test/HbsHelpers/ModPartialTests.cs
+++ b/YuzuDelivery.Core.Test/HbsHelpers/ModPartialTests.cs
@@ -1,0 +1,94 @@
+﻿using System.IO;
+using HandlebarsDotNet;
+using NUnit.Framework;
+using YuzuDelivery.Core;
+
+namespace YuzuDelivery.Core.Test.HbsHelpers
+{
+    
+    public class ModPartialTests
+    {
+        private YuzuDelivery.Core.ModPartial helper;
+        [SetUp]
+        public void Setup()
+        {
+            helper = new YuzuDelivery.Core.ModPartial();
+        }
+        
+        [Test]
+        public void given_path_and_context_where_context_is_an_object_and_modifiers_is_empty()
+        {
+            var source = "{{{modPartial 'partialName' foo ''}}}";
+            var partialSource = "test {{bar}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar", output);
+        }
+
+        [Test]
+        public void given_path_context_and_parameter()
+        {
+            var source = "{{{modPartial 'partialName' foo param='test'}}}";
+            var partialSource = "test {{bar}} {{param}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar test", output);
+        }
+        
+        [Test]
+        public void given_path_context_and_multiple_parameters()
+        {
+            var source = "{{{modPartial 'partialName' foo param1='test' param2='test again'}}}";
+            var partialSource = "test {{bar}} {{param1}} {{param2}}";
+            var template = Handlebars.Compile(source);
+            
+            using(var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partialTemplate);
+            }
+            
+            var data = new
+            {
+                foo = new
+                {
+                    bar = "foo bar"
+                }
+            };
+
+            var output = template(data);
+            Assert.AreEqual("test foo bar test test again", output);
+        }
+
+    }
+}

--- a/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
+++ b/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
 using Newtonsoft.Json;
+using YuzuDelivery.Core.Helpers;
 
 namespace YuzuDelivery.Core
 {
@@ -42,61 +43,13 @@ namespace YuzuDelivery.Core
 
                 if (parameters.Length > 1)
                 {
-                    r(writer, GetDataModel(parameters, context) ?? parameters[1]);
+                    r(writer, PartialHelpers.GetDataModel(parameters, context) ?? parameters[1]);
                 }
                 else
                 {
                     r(writer, context);
                 }
             });
-        }
-
-        private static bool IsSimple(Type type)
-        {
-            return type.IsPrimitive
-                   || type == typeof(string);
-        }
-
-        private static Dictionary<string, object> GetDataModel(object[] parameters, dynamic context)
-        {
-            var properties = new Dictionary<string, object>();
-
-            var paramType = parameters[1].GetType();
-            // we cannot support hashParameters when the base type is a simple type
-            if (IsSimple(paramType))
-            {
-                return null;
-            }
-            
-            if (paramType != typeof(HashParameterDictionary))
-            {
-                //not sure what is faster
-                // linq:
-                properties = paramType.GetProperties().ToDictionary(
-                    property => StringExtensions.FirstCharacterToLower(property.Name),
-                    property => property.GetValue(parameters[1]));
-
-                //jsonSerialize/deserialize:
-                //var json = JsonConvert.SerializeObject(parameters[1]);
-                //var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(json); 
-            }
-            // when context is implicitly given
-            else
-            {
-                properties = ((object)context).GetType().GetProperties().ToDictionary(
-                    property => StringExtensions.FirstCharacterToLower(property.Name),
-                    property => property.GetValue(context));
-            }
-
-            if (!(parameters[parameters.Length - 1] is HashParameterDictionary hashParameterDictionary))
-                return properties;
-
-            foreach (var parameter in hashParameterDictionary)
-            {
-                properties.Add(parameter.Key, parameter.Value);
-            }
-
-            return  properties;
         }
     }
 }

--- a/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
+++ b/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
@@ -1,20 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using HandlebarsDotNet;
+using HandlebarsDotNet.Compiler;
 
 namespace YuzuDelivery.Core
 {
     public class DynPartial
     {
-
-        public class DynPartial
-    {
-      
         public DynPartial()
         {
-            HandlebarsDotNet.Handlebars.RegisterHelper("dynPartial", (writer , context, parameters) =>
+            HandlebarsDotNet.Handlebars.RegisterHelper("dynPartial", (writer, context, parameters) =>
             {
                 var _ref = string.Empty;
                 if (parameters[0] != null)
@@ -27,10 +22,12 @@ namespace YuzuDelivery.Core
                     {
                         vmType = vmType.GetElementType();
                     }
+
                     if (vmType.IsGenericType)
                     {
                         vmType = vmType.GetGenericArguments().FirstOrDefault();
                     }
+
                     _ref = vmType.Name.Replace("vmBlock_", "par");
                 }
 
@@ -45,29 +42,26 @@ namespace YuzuDelivery.Core
                 {
                     //not sure what is faster
                     // linq:
-                    var properties = parameters[1].GetType().GetProperties().ToDictionary(property => StringExtensions.FirstCharacterToLower(property.Name),
-                      property => property.GetValue(parameters[1]));
-                    
+                    var properties = parameters[1].GetType().GetProperties().ToDictionary(
+                        property => StringExtensions.FirstCharacterToLower(property.Name),
+                        property => property.GetValue(parameters[1]));
+
                     //jsonSerialize/deserialize:
                     //var json = JsonConvert.SerializeObject(parameters[1]);
                     //var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(json); 
-                    
+
                     foreach (var property in hashParameterDictionary)
                     {
                         properties.Add(property.Key, property.Value);
                     }
-                    
+
                     r(writer, properties);
                 }
                 else
                 {
                     r(writer, parameters[1]);
                 }
-
             });
         }
-    }
-
-
     }
 }

--- a/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
+++ b/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
+using Newtonsoft.Json;
 
 namespace YuzuDelivery.Core
 {
@@ -38,30 +40,63 @@ namespace YuzuDelivery.Core
                 if (r == null)
                     throw new Exception(string.Format("dynPartial error : Partial not found for ref {0}", _ref));
 
-                if (parameters.Length > 2 && parameters[2] is HashParameterDictionary hashParameterDictionary)
+                if (parameters.Length > 1)
                 {
-                    //not sure what is faster
-                    // linq:
-                    var properties = parameters[1].GetType().GetProperties().ToDictionary(
-                        property => StringExtensions.FirstCharacterToLower(property.Name),
-                        property => property.GetValue(parameters[1]));
-
-                    //jsonSerialize/deserialize:
-                    //var json = JsonConvert.SerializeObject(parameters[1]);
-                    //var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(json); 
-
-                    foreach (var property in hashParameterDictionary)
-                    {
-                        properties.Add(property.Key, property.Value);
-                    }
-
-                    r(writer, properties);
+                    r(writer, GetDataModel(parameters, context) ?? parameters[1]);
                 }
                 else
                 {
-                    r(writer, parameters[1]);
+                    r(writer, context);
                 }
             });
+        }
+
+        private static bool IsSimple(Type type)
+        {
+            return type.IsPrimitive
+                   || type == typeof(string);
+        }
+
+        private static Dictionary<string, object> GetDataModel(object[] parameters, dynamic context)
+        {
+            var properties = new Dictionary<string, object>();
+
+            var paramType = parameters[1].GetType();
+            // we cannot support hashParameters when the base type is a simple type
+            if (IsSimple(paramType))
+            {
+                return null;
+            }
+            
+            if (paramType != typeof(HashParameterDictionary))
+            {
+                //not sure what is faster
+                // linq:
+                properties = paramType.GetProperties().ToDictionary(
+                    property => StringExtensions.FirstCharacterToLower(property.Name),
+                    property => property.GetValue(parameters[1]));
+
+                //jsonSerialize/deserialize:
+                //var json = JsonConvert.SerializeObject(parameters[1]);
+                //var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(json); 
+            }
+            // when context is implicitly given
+            else
+            {
+                properties = ((object)context).GetType().GetProperties().ToDictionary(
+                    property => StringExtensions.FirstCharacterToLower(property.Name),
+                    property => property.GetValue(context));
+            }
+
+            if (!(parameters[parameters.Length - 1] is HashParameterDictionary hashParameterDictionary))
+                return properties;
+
+            foreach (var parameter in hashParameterDictionary)
+            {
+                properties.Add(parameter.Key, parameter.Value);
+            }
+
+            return  properties;
         }
     }
 }

--- a/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
+++ b/YuzuDelivery.Core/HbsHelpers/DynPartial.cs
@@ -9,9 +9,12 @@ namespace YuzuDelivery.Core
     public class DynPartial
     {
 
+        public class DynPartial
+    {
+      
         public DynPartial()
         {
-            HandlebarsDotNet.Handlebars.RegisterHelper("dynPartial", (writer, context, parameters) =>
+            HandlebarsDotNet.Handlebars.RegisterHelper("dynPartial", (writer , context, parameters) =>
             {
                 var _ref = string.Empty;
                 if (parameters[0] != null)
@@ -38,9 +41,32 @@ namespace YuzuDelivery.Core
                 if (r == null)
                     throw new Exception(string.Format("dynPartial error : Partial not found for ref {0}", _ref));
 
-                r(writer, parameters[1]);
+                if (parameters.Length > 2 && parameters[2] is HashParameterDictionary hashParameterDictionary)
+                {
+                    //not sure what is faster
+                    // linq:
+                    var properties = parameters[1].GetType().GetProperties().ToDictionary(property => StringExtensions.FirstCharacterToLower(property.Name),
+                      property => property.GetValue(parameters[1]));
+                    
+                    //jsonSerialize/deserialize:
+                    //var json = JsonConvert.SerializeObject(parameters[1]);
+                    //var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(json); 
+                    
+                    foreach (var property in hashParameterDictionary)
+                    {
+                        properties.Add(property.Key, property.Value);
+                    }
+                    
+                    r(writer, properties);
+                }
+                else
+                {
+                    r(writer, parameters[1]);
+                }
+
             });
         }
+    }
 
 
     }

--- a/YuzuDelivery.Core/HbsHelpers/ModPartial.cs
+++ b/YuzuDelivery.Core/HbsHelpers/ModPartial.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Dynamic;
 using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
+using HandlebarsDotNet.Compiler;
 
 namespace YuzuDelivery.Core
 {
@@ -86,16 +86,18 @@ namespace YuzuDelivery.Core
                 properties.Remove("_modifiers");
             }
 
-            properties.TryAdd("_modifiers", modifiers);
-
-            if (parameters[^1] is not HashParameterDictionary hashParameterDictionary)
-                return properties;
-
-            foreach (var (key, value) in hashParameterDictionary)
+            if (!properties.ContainsKey("_modifiers"))
             {
-                properties.Add(key, value);
+                properties.Add("_modifiers", modifiers);
             }
-
+            
+            if (!(parameters[parameters.Length - 1] is HashParameterDictionary hashParameterDictionary))
+                return properties;
+            
+            foreach ( var parameter in hashParameterDictionary)
+            {
+                properties.Add(parameter.Key, parameter.Value);
+            }
             return properties;
         }
     }

--- a/YuzuDelivery.Core/Helpers/PartialHelpers.cs
+++ b/YuzuDelivery.Core/Helpers/PartialHelpers.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using HandlebarsDotNet.Compiler;
+
+namespace YuzuDelivery.Core.Helpers
+{
+    public static class PartialHelpers
+    {
+        public static bool IsSimple(this Type type)
+        {
+            return type.IsPrimitive
+                   || type == typeof(string);
+        }
+        
+        public static Dictionary<string, object> GetDataModel(object[] parameters, dynamic context = null)
+        {
+            var paramType = parameters[1].GetType();
+            var properties = new Dictionary<string, object>();
+            //we can't support modifiers and hashParameters on base types
+            if (paramType.IsSimple())
+            {
+                return null;
+            }
+            
+            var modifiers = parameters.Where((source, index) => index > 1)
+                .Where(x => x != null && x.GetType().IsSimple())
+                .Select(x => x.ToString()).ToList();
+            
+            if (modifiers.Any())
+            {
+                if (properties.Any(property => property.Key == "_modifiers" && property.Value == null))
+                {
+                    properties.Remove("_modifiers");
+                }
+
+                if (!properties.ContainsKey("_modifiers"))
+                {
+                    properties.Add("_modifiers", modifiers);
+                }
+            }
+            
+            if (paramType != typeof(HashParameterDictionary))
+            {
+                //not sure what is faster
+                // linq:
+                properties = paramType.GetProperties().ToDictionary(
+                    property => StringExtensions.FirstCharacterToLower(property.Name),
+                    property => property.GetValue(parameters[1]));
+
+                //jsonSerialize/deserialize:
+                //var json = JsonConvert.SerializeObject(parameters[1]);
+                //var properties = JsonConvert.DeserializeObject<Dictionary<string, object>>(json); 
+            }
+            // when context is implicitly given
+            else if(context != null)
+            {
+                properties = ((object)context).GetType().GetProperties().ToDictionary(
+                    property => StringExtensions.FirstCharacterToLower(property.Name),
+                    property => property.GetValue(context));
+            }
+            
+            if (!(parameters[parameters.Length - 1] is HashParameterDictionary hashParameterDictionary))
+                return properties;
+
+            foreach (var parameter in hashParameterDictionary)
+            {
+                properties.Add(parameter.Key, parameter.Value);
+            }
+
+            return properties;
+        }
+    }
+}

--- a/YuzuDelivery.Core/Helpers/PartialHelpers.cs
+++ b/YuzuDelivery.Core/Helpers/PartialHelpers.cs
@@ -17,8 +17,8 @@ namespace YuzuDelivery.Core.Helpers
         {
             var paramType = parameters[1].GetType();
             var properties = new Dictionary<string, object>();
-            //we can't support modifiers and hashParameters on base types
-            if (paramType.IsSimple())
+            //we can't support modifiers and hashParameters on generic types
+            if (paramType.IsSimple() || paramType.IsArray)
             {
                 return null;
             }

--- a/YuzuDelivery.Core/Helpers/PartialHelpers.cs
+++ b/YuzuDelivery.Core/Helpers/PartialHelpers.cs
@@ -18,7 +18,7 @@ namespace YuzuDelivery.Core.Helpers
             var paramType = parameters[1].GetType();
             var properties = new Dictionary<string, object>();
             //we can't support modifiers and hashParameters on generic types
-            if (paramType.IsSimple() || paramType.IsArray)
+            if (paramType.IsSimple() || paramType.IsArray || paramType.IsGenericType)
             {
                 return null;
             }


### PR DESCRIPTION
Adds support for (hash)parameters in modPartial and dynPartial

[see also:](https://github.com/balanced-dev/yuzu-definition-hbs-helpers/pull/1)